### PR TITLE
Trim user info

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,3 @@
+.git
+node_modules
+manifest.yml

--- a/src/stores/UserStore.js
+++ b/src/stores/UserStore.js
@@ -25,6 +25,8 @@ class UserStore extends BaseStore {
       _rev: user._rev,
       name: user.name ? user.name : decodeURIComponent(user.cn),
       email: user.email ? user.email : user.emailAddress,
+      createdAt: user.createdAt,
+      updatedAt: user.updatedAt,
       address: user.address
     };
 

--- a/src/stores/UserStore.js
+++ b/src/stores/UserStore.js
@@ -23,8 +23,8 @@ class UserStore extends BaseStore {
     var trimmedUser = {
       _id: user._id,
       _rev: user._rev,
-      name: user.name ? user.name : user.cn,
-      email: user.email ? user.email :user.emailAddress,
+      name: user.name ? user.name : decodeURIComponent(user.cn),
+      email: user.email ? user.email : user.emailAddress,
       address: user.address
     };
 


### PR DESCRIPTION
Reduce user info stored and returned by the API. Store only what is needed for the starter app to function and make a uniform model for the dashboards to use.